### PR TITLE
Create endpoints For CRUD Announcements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 # C extensions
 *.so
 
+
+
 # Distribution / packaging
 .Python
 build/
@@ -25,6 +27,13 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea/.gitignore
+.idea/CommunityBackendService.iml
+.idea/inspectionProfiles/Project_Default.xml
+.idea/inspectionProfiles/profiles_settings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/CommunityBackendService.iml
+++ b/.idea/CommunityBackendService.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,13 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N806" />
+          <option value="N802" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (CommunityBackendService)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CommunityBackendService.iml" filepath="$PROJECT_DIR$/.idea/CommunityBackendService.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from contextlib import asynccontextmanager
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None,None]:
-    # Startup
     create_tables()
     yield
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import uvicorn
 from fastapi import FastAPI
 from typing import AsyncGenerator
 from utils.init_db import create_tables
-from routers import user_router
+from routers import user_router, announcement_router
 from contextlib import asynccontextmanager
 
 @asynccontextmanager
@@ -14,6 +14,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None,None]:
 app = FastAPI(lifespan=lifespan)
 
 app.include_router(user_router.router)
+app.include_router(announcement_router.router)
 
 @app.get("/")
 def read_root():

--- a/models/announcement.py
+++ b/models/announcement.py
@@ -2,7 +2,6 @@
 from sqlalchemy import Column, Integer, String, Text, DateTime
 from database import Base
 
-
 class Announcement(Base):
     __tablename__ = "announcements"
 

--- a/models/announcement.py
+++ b/models/announcement.py
@@ -1,0 +1,14 @@
+# models/announcement.py
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from database import Base
+
+
+class Announcement(Base):
+    __tablename__ = "announcements"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, unique=True)
+    description = Column(Text)
+    announcement_date = Column(DateTime)
+    announcement_deadline = Column(DateTime, nullable=True)
+    image = Column(String, nullable=True)

--- a/repository/announcement_repository.py
+++ b/repository/announcement_repository.py
@@ -1,0 +1,47 @@
+from typing import Optional, List, Type
+from sqlalchemy.orm import Session
+from models.announcement import Announcement
+from schemas.announcement_schema import AnnouncementCreate, AnnouncementUpdate
+from utils.singleton_meta import SingletonMeta
+
+
+class AnnouncementRepository(metaclass=SingletonMeta):
+    def __init__(self, session: Session):
+        self.session = session
+
+    def add_announcement(self, announcement: AnnouncementCreate) -> Announcement:
+        # Create a new Announcement object from the AnnouncementCreate schema
+        db_announcement = Announcement()
+        for key, value in announcement.dict().items():
+            setattr(db_announcement, key, value)
+
+        self.session.add(db_announcement)
+        self.session.commit()
+        self.session.refresh(db_announcement)
+        return db_announcement
+
+    def get_announcements(self) -> list[Type[Announcement]]:
+        return self.session.query(Announcement).all()
+
+    def get_announcement_by_id(self, announcement_id: int) -> Optional[Announcement]:
+        return self.session.query(Announcement).filter(Announcement.id == announcement_id).first()
+
+    def update_announcement(self, announcement_id: int, announcement: AnnouncementUpdate):
+        db_announcement = self.get_announcement_by_id(announcement_id)
+        if db_announcement:
+            for key, value in announcement.dict().items():
+                setattr(db_announcement, key, value)
+            self.session.commit()
+            self.session.refresh(db_announcement)
+        return db_announcement
+
+    def delete_announcement(self, announcement_id: int) -> Optional[Announcement]:
+        db_announcement = self.get_announcement_by_id(announcement_id)
+        if db_announcement:
+            self.session.delete(db_announcement)
+            self.session.commit()
+
+        return db_announcement
+
+    def get_announcement_by_title(self, title) -> Optional[Announcement]:
+        return self.session.query(Announcement).filter(Announcement.title == title).first()

--- a/repository/announcement_repository.py
+++ b/repository/announcement_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Type
+from typing import Optional, Type
 from sqlalchemy.orm import Session
 from models.announcement import Announcement
 from schemas.announcement_schema import AnnouncementCreate, AnnouncementUpdate
@@ -10,11 +10,7 @@ class AnnouncementRepository(metaclass=SingletonMeta):
         self.session = session
 
     def add_announcement(self, announcement: AnnouncementCreate) -> Announcement:
-        # Create a new Announcement object from the AnnouncementCreate schema
-        db_announcement = Announcement()
-        for key, value in announcement.dict().items():
-            setattr(db_announcement, key, value)
-
+        db_announcement = Announcement(**announcement.model_dump())
         self.session.add(db_announcement)
         self.session.commit()
         self.session.refresh(db_announcement)
@@ -26,10 +22,10 @@ class AnnouncementRepository(metaclass=SingletonMeta):
     def get_announcement_by_id(self, announcement_id: int) -> Optional[Announcement]:
         return self.session.query(Announcement).filter(Announcement.id == announcement_id).first()
 
-    def update_announcement(self, announcement_id: int, announcement: AnnouncementUpdate):
+    def update_announcement(self, announcement_id: int, announcement: AnnouncementUpdate) -> Optional[Announcement]:
         db_announcement = self.get_announcement_by_id(announcement_id)
         if db_announcement:
-            for key, value in announcement.dict().items():
+            for key, value in announcement.model_dump().items():
                 setattr(db_announcement, key, value)
             self.session.commit()
             self.session.refresh(db_announcement)
@@ -40,8 +36,7 @@ class AnnouncementRepository(metaclass=SingletonMeta):
         if db_announcement:
             self.session.delete(db_announcement)
             self.session.commit()
-
         return db_announcement
 
-    def get_announcement_by_title(self, title) -> Optional[Announcement]:
+    def get_announcement_by_title(self, title: str) -> Optional[Announcement]:
         return self.session.query(Announcement).filter(Announcement.title == title).first()

--- a/repository/user_repository.py
+++ b/repository/user_repository.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from models.user import User
 from utils.singleton_meta import SingletonMeta
 
+
 class UserRepository(metaclass=SingletonMeta):
     def __init__(self, session):
         self.db: Session = session
@@ -12,10 +13,9 @@ class UserRepository(metaclass=SingletonMeta):
         self.db.commit()
         self.db.refresh(user)
         return user
-    
+
     def get_user_by_email(self, email: str) -> Optional[User]:
         return self.db.query(User).filter(User.email == email).first()
-
 
     def delete_user(self, email: str) -> None:
         user = self.get_user_by_email(email)

--- a/routers/announcement_router.py
+++ b/routers/announcement_router.py
@@ -33,7 +33,7 @@ def get_announcement_by_id(announcement_id: int, session: Session = Depends(get_
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
-@router.put("/announcements/{announcement_id}", status_code=status.HTTP_200_OK, response_model=AnnouncementUpdate)
+@router.put("/announcements/{announcement_id}", status_code=status.HTTP_200_OK, response_model=AnnouncementCreate)
 def update_announcement(announcement_id: int, announcement: AnnouncementUpdate,
                         session: Session = Depends(get_db)) -> AnnouncementUpdate:
     service = AnnouncementService(session=session)

--- a/routers/announcement_router.py
+++ b/routers/announcement_router.py
@@ -1,0 +1,53 @@
+from typing import Type, List
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from database import get_db
+from schemas.announcement_schema import AnnouncementCreate, AnnouncementUpdate, AnnouncementResponse
+from services.announcement_service import AnnouncementService
+from models.announcement import Announcement
+
+router = APIRouter()
+
+
+@router.post("/announcements/", status_code=status.HTTP_201_CREATED, response_model=AnnouncementResponse)
+def create_announcement(announcement: AnnouncementCreate, session: Session = Depends(get_db)) -> AnnouncementResponse:
+    service = AnnouncementService(session=session)
+    try:
+        return service.create_announcement(announcement)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/announcements/", status_code=status.HTTP_200_OK, response_model=list[AnnouncementCreate])
+def get_all_announcements(session: Session = Depends(get_db)) -> list[AnnouncementCreate]:
+    service = AnnouncementService(session=session)
+    return service.get_all_announcements()
+
+
+@router.get("/announcements/{announcement_id}", status_code=status.HTTP_200_OK, response_model=AnnouncementCreate)
+def get_announcement_by_id(announcement_id: int, session: Session = Depends(get_db)) -> Announcement:
+    service = AnnouncementService(session=session)
+    try:
+        return service.get_announcement_by_id(announcement_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.put("/announcements/{announcement_id}", status_code=status.HTTP_200_OK, response_model=AnnouncementUpdate)
+def update_announcement(announcement_id: int, announcement: AnnouncementUpdate,
+                        session: Session = Depends(get_db)) -> AnnouncementUpdate:
+    service = AnnouncementService(session=session)
+    try:
+        return service.update_announcement(announcement_id, announcement)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.delete("/announcements/{announcement_id}", status_code=status.HTTP_200_OK, response_model=AnnouncementResponse)
+def delete_announcement(announcement_id: int, session: Session = Depends(get_db)) -> AnnouncementResponse:
+    service = AnnouncementService(session=session)
+    try:
+        service.delete_announcement(announcement_id)
+        return AnnouncementResponse(id=announcement_id, message="Announcement deleted successfully.")
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/schemas/announcement_schema.py
+++ b/schemas/announcement_schema.py
@@ -18,26 +18,20 @@ class AnnouncementCreate(BaseModel):
 
 
 class AnnouncementUpdate(BaseModel):
-    id: int
     title: Optional[str] = None
     description: Optional[str] = None
     announcement_date: Optional[datetime] = None
     announcement_deadline: Optional[datetime] = None
     image: Optional[str] = None
 
-    #model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, orm_mode=True)
 
-    class Config:
-        orm_mode = True
-        from_attributes = True
+
 
 
 class AnnouncementResponse(BaseModel):
     id: Optional[int] = None
     message: Optional[str] = None
 
-    class Config:
-        orm_mode = True
-        from_attributes = True
 
-    #model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, orm_mode=True)

--- a/schemas/announcement_schema.py
+++ b/schemas/announcement_schema.py
@@ -1,0 +1,43 @@
+# schemas/announcement_schema.py
+from pydantic import BaseModel, root_validator, model_validator, ConfigDict
+from typing import Optional
+from datetime import datetime
+
+
+class AnnouncementCreate(BaseModel):
+    id: Optional[int] = None
+    title: str
+    description: str
+    announcement_date: datetime
+    announcement_deadline: Optional[datetime] = None
+    image: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+        from_attributes = True
+
+
+class AnnouncementUpdate(BaseModel):
+    id: int
+    title: Optional[str] = None
+    description: Optional[str] = None
+    announcement_date: Optional[datetime] = None
+    announcement_deadline: Optional[datetime] = None
+    image: Optional[str] = None
+
+    #model_config = ConfigDict(from_attributes=True)
+
+    class Config:
+        orm_mode = True
+        from_attributes = True
+
+
+class AnnouncementResponse(BaseModel):
+    id: Optional[int] = None
+    message: Optional[str] = None
+
+    class Config:
+        orm_mode = True
+        from_attributes = True
+
+    #model_config = ConfigDict(from_attributes=True)

--- a/schemas/user_schema.py
+++ b/schemas/user_schema.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from pydantic import BaseModel, ConfigDict, EmailStr
 
+
 class UserCreate(BaseModel):
     email: EmailStr
     first_name: str
@@ -15,12 +16,14 @@ class UserCreate(BaseModel):
     linkedin_profile: Optional[str] = None
     mentor_email: Optional[str] = None
 
+
 class UserCreatedResponse(BaseModel):
     email: str
     first_name: str
     last_name: str
-    
+
     model_config = ConfigDict(from_attributes=True)
+
 
 class UserDeletedResponse(BaseModel):
     message: str

--- a/services/announcement_service.py
+++ b/services/announcement_service.py
@@ -1,6 +1,5 @@
-from typing import Optional, List, Type
+from typing import Optional
 from sqlalchemy.orm import Session
-from models.announcement import Announcement
 from repository.announcement_repository import AnnouncementRepository
 from schemas.announcement_schema import AnnouncementCreate, AnnouncementUpdate, AnnouncementResponse
 
@@ -11,7 +10,6 @@ class AnnouncementService:
         self.repository = AnnouncementRepository(session)
 
     def create_announcement(self, announcement: AnnouncementCreate) -> AnnouncementResponse:
-        # check if announcement already exists
         if self.repository.get_announcement_by_title(announcement.title):
             raise ValueError("Announcement with this title already exists.")
 
@@ -29,8 +27,9 @@ class AnnouncementService:
         return AnnouncementCreate.from_orm(self.repository.get_announcement_by_id(announcement_id))
 
     def update_announcement(self, announcement_id: int, announcement: AnnouncementUpdate) -> Optional[
-        AnnouncementUpdate]:
-        return AnnouncementUpdate.from_orm(self.repository.update_announcement(announcement_id, announcement))
+        AnnouncementCreate]:
+        updated_announcement = self.repository.update_announcement(announcement_id, announcement)
+        return AnnouncementCreate.model_validate(updated_announcement)
 
     def delete_announcement(self, announcement_id: int) -> None:
         announcement = self.repository.delete_announcement(announcement_id)

--- a/services/announcement_service.py
+++ b/services/announcement_service.py
@@ -1,0 +1,38 @@
+from typing import Optional, List, Type
+from sqlalchemy.orm import Session
+from models.announcement import Announcement
+from repository.announcement_repository import AnnouncementRepository
+from schemas.announcement_schema import AnnouncementCreate, AnnouncementUpdate, AnnouncementResponse
+
+
+class AnnouncementService:
+
+    def __init__(self, session: Session):
+        self.repository = AnnouncementRepository(session)
+
+    def create_announcement(self, announcement: AnnouncementCreate) -> AnnouncementResponse:
+        # check if announcement already exists
+        if self.repository.get_announcement_by_title(announcement.title):
+            raise ValueError("Announcement with this title already exists.")
+
+        # Check if announcement date is before announcement deadline
+        if announcement.announcement_date >= announcement.announcement_deadline:
+            raise ValueError("Announcement date must be before announcement deadline.")
+
+        return AnnouncementResponse.from_orm(self.repository.add_announcement(announcement))
+
+    def get_all_announcements(self) -> list[AnnouncementCreate]:
+        announcements = self.repository.get_announcements()
+        return [AnnouncementCreate.from_orm(announcement) for announcement in announcements]
+
+    def get_announcement_by_id(self, announcement_id: int) -> Optional[AnnouncementCreate]:
+        return AnnouncementCreate.from_orm(self.repository.get_announcement_by_id(announcement_id))
+
+    def update_announcement(self, announcement_id: int, announcement: AnnouncementUpdate) -> Optional[
+        AnnouncementUpdate]:
+        return AnnouncementUpdate.from_orm(self.repository.update_announcement(announcement_id, announcement))
+
+    def delete_announcement(self, announcement_id: int) -> None:
+        announcement = self.repository.delete_announcement(announcement_id)
+        if not announcement:
+            raise ValueError("Announcement not found")

--- a/tests/announcement_test.py
+++ b/tests/announcement_test.py
@@ -1,0 +1,127 @@
+import tempfile
+import pytest
+from typing import Generator
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from main import app
+from database import get_db
+from models.announcement import Announcement
+
+
+def override_get_db() -> Generator[Session, None, None]:
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_and_teardown_db() -> Generator[TestClient, None, None]:
+    Announcement.metadata.create_all(bind=engine)
+    yield client
+    app.dependency_overrides.clear()
+    Announcement.metadata.drop_all(bind=engine)
+    engine.dispose()
+
+
+temp_db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+SQLALCHEMY_TEST_DATABASE_URL = f"sqlite:///{temp_db_file.name}"
+engine = create_engine(SQLALCHEMY_TEST_DATABASE_URL)
+
+app.dependency_overrides[get_db] = override_get_db
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+client = TestClient(app)
+
+
+def test_create_get_announcement() -> None:
+    create_route = "/announcements/"
+    response = client.post(
+        create_route,
+        json={
+            "title": "Test Announcement",
+            "description": "This is a test announcement.",
+            "announcement_date": "2023-10-10T10:00:00",
+            "announcement_deadline": "2023-12-31T23:59:59",
+            "image": "test_image_url"
+        },
+    )
+
+    assert response.status_code == 201
+    announcement_id: int = response.json()["id"]
+    get_route = f"/announcements/{announcement_id}"
+    response = client.get(get_route)
+    assert response.status_code == 200
+    assert response.json()["id"] == announcement_id
+    assert response.json()["title"] == "Test Announcement"
+
+
+def test_get_non_existing_announcement() -> None:
+    response = client.get("/announcements/999")
+    assert response.status_code == 404
+
+
+def test_create_announcement_duplicate() -> None:
+    response = client.post(
+        "/announcements/",
+        json={
+            "title": "Duplicate Announcement",
+            "description": "This is a duplicate announcement.",
+            "announcement_date": "2023-10-10T10:00:00",
+            "announcement_deadline": "2023-12-31T23:59:59",
+            "image": "duplicate_image_url"
+        },
+    )
+    assert response.status_code == 201
+    response = client.post(
+        "/announcements/",
+        json={
+            "title": "Duplicate Announcement",
+            "description": "This is a duplicate announcement.",
+            "announcement_date": "2023-10-10T10:00:00",
+            "announcement_deadline": "2023-12-31T23:59:59",
+            "image": "duplicate_image_url"
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Announcement with this title already exists."
+
+
+def test_create_announcement_date_before_deadline() -> None:
+    response = client.post(
+        "/announcements/",
+        json={
+            "title": "Date Before Deadline",
+            "description": "This announcement has a date before the deadline.",
+            "announcement_date": "2023-12-31T10:00:00",
+            "announcement_deadline": "2023-12-31T09:59:59",
+            "image": "date_before_deadline_image_url"
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Announcement date must be before announcement deadline."
+
+
+def test_delete_existing_announcement() -> None:
+    create_response = client.post(
+        "/announcements/",
+        json={
+            "title": "Delete Announcement",
+            "description": "This announcement will be deleted.",
+            "announcement_date": "2023-10-10T10:00:00",
+            "announcement_deadline": "2023-12-31T23:59:59",
+            "image": "delete_image_url"
+        },
+    )
+    assert create_response.status_code == 201
+    new_announcement = create_response.json()
+    announcement_id = new_announcement["id"]
+    delete_route = f"/announcements/{announcement_id}"
+    delete_response = client.delete(delete_route)
+    assert delete_response.status_code == 200
+    assert delete_response.json()["id"] == announcement_id
+    assert delete_response.json()["message"] == "Announcement deleted successfully."
+    delete_response = client.delete(delete_route)
+    assert delete_response.status_code == 404
+    assert delete_response.json()["detail"] == "Announcement not found"

--- a/tests/announcement_test.py
+++ b/tests/announcement_test.py
@@ -2,12 +2,13 @@ from typing import Generator
 from fastapi.testclient import TestClient
 import pytest
 from models.announcement import Announcement
-from tests.test_fixtures import create_and_teardown_tables,client
+from tests.test_fixtures import create_and_teardown_tables, client
 
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_and_teardown_db() -> Generator[TestClient, None, None]:
     yield from create_and_teardown_tables(Announcement.metadata)
+
 
 def test_create_get_announcement() -> None:
     create_route = "/announcements/"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,31 @@
+import tempfile
+from typing import Generator
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+from fastapi.testclient import TestClient
+from main import app
+from database import get_db
+
+temp_db_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+SQLALCHEMY_TEST_DATABASE_URL = f"sqlite:///{temp_db_file.name}"
+engine = create_engine(SQLALCHEMY_TEST_DATABASE_URL)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+client = TestClient(app)
+
+def override_get_db() -> Generator[Session, None, None]:
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+def create_and_teardown_tables(metadata) -> Generator[TestClient, None, None]:
+    metadata.create_all(bind=engine)
+    yield client
+    metadata.drop_all(bind=engine)
+
+def pytest_sessionfinish(session, exitstatus):
+    engine.dispose()
+    app.dependency_overrides.clear()

--- a/utils/func_utils.py
+++ b/utils/func_utils.py
@@ -1,6 +1,4 @@
 import bcrypt
 
-from services.user_service import UserService
-
 def get_password_hash(password:str) -> str: 
     return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')

--- a/utils/init_db.py
+++ b/utils/init_db.py
@@ -1,6 +1,8 @@
 from models.user import User
+from models.announcement import Announcement
 from database import engine
 
 def create_tables():
 
     User.metadata.create_all(bind=engine)
+    Announcement.metadata.create_all(bind=engine)


### PR DESCRIPTION
## WHY
- Closes #7

## WHAT
1- Design logic to handle Announcement, cancel News (didn't find it relevant for this scope, let's treat everything as announcement for the beginning)
2- An announcement is uniquely identified by its title, but I've added a surrogate key id (auto increment)
3- I didn't find it useful to add the author of the announcement, as everything is posted by the community executive from the back office! (What is your thought?)
4- Handled all endpoints for CRUD.
5- Designed Unit tests for everything.
## TESTING

![test-community001](https://github.com/user-attachments/assets/14a13ebb-fe9d-4924-a8e9-0829b9722175)
