### PR TITLE
Change get_all_users to only return active_users

### DIFF
--- a/repository/user_repository.py
+++ b/repository/user_repository.py
@@ -31,7 +31,7 @@ class UserRepository(metaclass=SingletonMeta):
         return self.db.query(User).filter(User.email == email).first()
 
     def get_users(self) -> List[User]:
-        return self.db.query(User).all()
+        return self.db.query(User).filter(User.is_active == True).all()    
 
     def update_user(self, user: User) -> Optional[User]:
         try:

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -61,12 +61,21 @@ def test_get_all_users() -> None:
             "first_name": "Test1",
             "last_name": "User1",
             "password": "securepassword",
+            "is_active": True,
         },
         {
             "email": "test_email2@example.com",
             "first_name": "Test2",
             "last_name": "User2",
             "password": "anothersecurepassword",
+            "is_active": False,
+        },
+        {
+            "email": "test_email3@example.com",
+            "first_name": "Test3",
+            "last_name": "User3",
+            "password": "anothersecurepassword",
+            "is_active": True,
         }
     ]
 
@@ -79,12 +88,18 @@ def test_get_all_users() -> None:
 
     response_data = response.json()
     assert isinstance(response_data, list)
-    assert len(response_data) == len(users_data)
+    
+    # Check that only active users are returned
+    active_users = [user for user in users_data if user["is_active"]]
+    assert len(response_data) == len(active_users)
 
-    for i, user in enumerate(users_data):
-        assert response_data[i]["email"] == user["email"]
-        assert response_data[i]["first_name"] == user["first_name"]
-        assert response_data[i]["last_name"] == user["last_name"]
+    # Verify that each active user is in the response
+    for active_user in active_users:
+        assert any(u["email"] == active_user["email"] for u in response_data)
+    
+     # Verify that no inactive user is in the response
+    for inactive_user in [user for user in users_data if not user["is_active"]]:
+        assert not any(u["email"] == inactive_user["email"] for u in response_data)
 
 
 def test_create_get_user() -> None:


### PR DESCRIPTION
## WHY
<!---Why is this change required? 
You can link issues that are part of this PR.--->
All accounts are currently "active" but we want some of them to be "inactive" based on our use cases:
EG:

- Someone not willing to be part of the community anymore and we do not just want to delete everything,
- We create an account for somebody for a test (let's say a 2007 batch) but we do not want to show it to the alumni directory
- In case we include memebership fee at some point, someone who has not paid the fee will have his account put on "hold".  

## WHAT

<!--- Change the get_all_users method to only return active users --->
Change the get_all_users method to only return active users

## TESTING

<!---Show your reviewer how things are tested. Whether they are unit tests, using PostMan to make API tests, include specific commands to test and screenshots when possible.---> 
