### PR TITLE
Bug fix - Prevent registration for past events

### DIFF
--- a/services/event_service.py
+++ b/services/event_service.py
@@ -7,7 +7,7 @@ from repository.user_event_repository import UserEventRepository
 from models.user import User
 from schemas.event_schema import EventCreate, EventRegistration, EventUpdate, EventWithAttendees
 from utils.singleton_meta import SingletonMeta
-from datetime import datetime
+from datetime import datetime, timezone
 
 class EventService(metaclass=SingletonMeta):
     def create_event(self, db: Session, event_data: EventCreate) -> Event:
@@ -28,20 +28,20 @@ class EventService(metaclass=SingletonMeta):
     def delete_event(self, db: Session, event_id: int) -> None:
         event_repository = EventRepository()
         event = event_repository.get_event_by_id(db, event_id)
-        
         if not event:
             raise ValueError("Event not found.")
         event_repository.delete_event(db, event_id)
 
     def register_user_for_event(self, db: Session, event_registration: EventRegistration, event_id: int) -> None:
+        event_repository = EventRepository()
         user_event_repository = UserEventRepository()
         user_email = event_registration.email
-        event_repository = EventRepository()
+        
         event = event_repository.get_event_by_id(db, event_id)
         if not event:
             raise ValueError("Event not found.")
-
-        current_time = datetime.utcnow()
+        
+        current_time = datetime.now(timezone.utc).replace(tzinfo=None)
         if event.end_time < current_time:
             raise ValueError("Cannot register for past events.")
         

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -3,11 +3,11 @@ from schemas.event_schema import EventCreate , EventResponse
 from schemas.user_schema import UserCreatedResponse
 from pydantic import TypeAdapter
 from typing import List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def test_create_event(client: TestClient) -> None:
-    future_time = datetime.utcnow() + timedelta(days=7)  
+    future_time = datetime.now(timezone.utc) + timedelta(days=7)
     event_data = {
         "title": "Test Event",
         "start_time": future_time.isoformat(),
@@ -24,7 +24,7 @@ def test_create_event(client: TestClient) -> None:
    
 
 def test_get_event_by_id(client: TestClient) -> None:
-    future_time = datetime.utcnow() + timedelta(days=7)
+    future_time = datetime.now(timezone.utc) + timedelta(days=7)
     event_data = {
         "title": "Test Event",
         "start_time": future_time.isoformat(),
@@ -43,7 +43,7 @@ def test_get_event_by_id(client: TestClient) -> None:
     assert fetched_event.location == "Event Location"
 
 def test_add_user_to_event(client: TestClient) -> None:
-    future_time = datetime.utcnow() + timedelta(days=7) 
+    future_time = datetime.now(timezone.utc) + timedelta(days=7)
     event_data = {
         "title": "Test Event",
         "start_time": future_time.isoformat(),
@@ -69,7 +69,7 @@ def test_add_user_to_event(client: TestClient) -> None:
     assert add_user_response.status_code == 200
 
 def test_remove_user_from_event(client: TestClient) -> None:
-    future_time = datetime.utcnow() + timedelta(days=7)  
+    future_time = datetime.now(timezone.utc) + timedelta(days=7)
     event_data = {
         "title": "Test Event",
         "start_time": future_time.isoformat(),
@@ -96,7 +96,7 @@ def test_remove_user_from_event(client: TestClient) -> None:
     assert remove_user_response.status_code == 200
 
 def test_get_all_event_attendees(client: TestClient) -> None:
-    future_time = datetime.utcnow() + timedelta(days=7)  
+    future_time = datetime.now(timezone.utc) + timedelta(days=7)
     event_data = {
         "title": "Test Event",
         "start_time": future_time.isoformat(),
@@ -126,13 +126,13 @@ def test_get_all_event_attendees(client: TestClient) -> None:
     attendees =  TypeAdapter(List[UserCreatedResponse]).validate_python(response.json())
     assert len(attendees) == 1
     assert attendees[0].email == user.email
+
 def test_cannot_register_for_past_event(client: TestClient) -> None:
-    """Test that users cannot register for past events"""
-    past_time = datetime.utcnow() - timedelta(days=1)
+    past_time = datetime.now(timezone.utc) - timedelta(days=1)
     event_data = {
         "title": "Past Event",
         "start_time": (past_time - timedelta(hours=2)).isoformat(),
-        "end_time": past_time.isoformat(),  # Ended yesterday
+        "end_time": past_time.isoformat(),
         "location": "Test Location",
         "description": "This event has already ended",
         "categories": "Test"
@@ -141,6 +141,7 @@ def test_cannot_register_for_past_event(client: TestClient) -> None:
     event_response = client.post("/events/", json=event_data)
     assert event_response.status_code == 201
     event: EventResponse = EventResponse.model_validate(event_response.json())
+    
     user_data = {
         "email": "pastuser@example.com",
         "first_name": "Past",
@@ -149,6 +150,7 @@ def test_cannot_register_for_past_event(client: TestClient) -> None:
     }
     user_response = client.post("/users/", json=user_data)
     assert user_response.status_code == 201
+    
     registration_response = client.post(
         f"/events/{event.id}/register", 
         json={'email': 'pastuser@example.com'}

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -7,10 +7,11 @@ from datetime import datetime, timedelta
 
 
 def test_create_event(client: TestClient) -> None:
+    future_time = datetime.utcnow() + timedelta(days=7)  
     event_data = {
         "title": "Test Event",
-        "start_time": "2025-01-24T11:30",
-        "end_time": "2025-01-24T17:30",
+        "start_time": future_time.isoformat(),
+        "end_time": (future_time + timedelta(hours=6)).isoformat(),
         "location": "Event Location",
         "description": "This is a test event",
         "categories": "Tech, Development",
@@ -23,10 +24,11 @@ def test_create_event(client: TestClient) -> None:
    
 
 def test_get_event_by_id(client: TestClient) -> None:
+    future_time = datetime.utcnow() + timedelta(days=7)
     event_data = {
         "title": "Test Event",
-        "start_time": "2025-01-24T11:30",
-        "end_time": "2025-01-24T17:30",
+        "start_time": future_time.isoformat(),
+        "end_time": (future_time + timedelta(hours=6)).isoformat(),
         "location": "Event Location",
         "description": "This is a test event",
         "categories": "Tech, Development",
@@ -41,10 +43,11 @@ def test_get_event_by_id(client: TestClient) -> None:
     assert fetched_event.location == "Event Location"
 
 def test_add_user_to_event(client: TestClient) -> None:
+    future_time = datetime.utcnow() + timedelta(days=7) 
     event_data = {
         "title": "Test Event",
-        "start_time": "2025-01-24T11:30",
-        "end_time": "2025-01-24T17:30",
+        "start_time": future_time.isoformat(),
+        "end_time": (future_time + timedelta(hours=6)).isoformat(),
         "location": "Event Location",
         "description": "This is a test event",
         "categories": "Tech, Development",
@@ -66,10 +69,11 @@ def test_add_user_to_event(client: TestClient) -> None:
     assert add_user_response.status_code == 200
 
 def test_remove_user_from_event(client: TestClient) -> None:
+    future_time = datetime.utcnow() + timedelta(days=7)  
     event_data = {
         "title": "Test Event",
-        "start_time": "2025-01-24T11:30",
-        "end_time": "2025-01-24T17:30",
+        "start_time": future_time.isoformat(),
+        "end_time": (future_time + timedelta(hours=6)).isoformat(),
         "location": "Event Location",
         "description": "This is a test event",
         "categories": "Tech, Development",
@@ -92,10 +96,11 @@ def test_remove_user_from_event(client: TestClient) -> None:
     assert remove_user_response.status_code == 200
 
 def test_get_all_event_attendees(client: TestClient) -> None:
+    future_time = datetime.utcnow() + timedelta(days=7)  
     event_data = {
         "title": "Test Event",
-        "start_time": "2025-01-24T11:30",
-        "end_time": "2025-01-24T17:30",
+        "start_time": future_time.isoformat(),
+        "end_time": (future_time + timedelta(hours=6)).isoformat(),
         "location": "Event Location",
         "description": "This is a test event",
         "categories": "Tech, Development",
@@ -120,12 +125,9 @@ def test_get_all_event_attendees(client: TestClient) -> None:
    
     attendees =  TypeAdapter(List[UserCreatedResponse]).validate_python(response.json())
     assert len(attendees) == 1
-    assert attendees[0].email ==user.email
+    assert attendees[0].email == user.email
 def test_cannot_register_for_past_event(client: TestClient) -> None:
     """Test that users cannot register for past events"""
-    from datetime import datetime, timedelta
-    
-    # Create a past event (ended yesterday)
     past_time = datetime.utcnow() - timedelta(days=1)
     event_data = {
         "title": "Past Event",
@@ -139,8 +141,6 @@ def test_cannot_register_for_past_event(client: TestClient) -> None:
     event_response = client.post("/events/", json=event_data)
     assert event_response.status_code == 201
     event: EventResponse = EventResponse.model_validate(event_response.json())
-    
-    # Create a user
     user_data = {
         "email": "pastuser@example.com",
         "first_name": "Past",
@@ -149,8 +149,6 @@ def test_cannot_register_for_past_event(client: TestClient) -> None:
     }
     user_response = client.post("/users/", json=user_data)
     assert user_response.status_code == 201
-    
-    # Try to register for the past event - should fail
     registration_response = client.post(
         f"/events/{event.id}/register", 
         json={'email': 'pastuser@example.com'}


### PR DESCRIPTION
Added validation to prevent users from registering for events that have already ended. The system now checks if an event's end_time is before the current time and raises a "Cannot register for past events" error.

## WHY
<!---Why is this change required? 
You can link issues that are part of this PR.--->
- Closes https://github.com/orgs/PkFokam-Alumni-Network/projects/2/views/1?filterQuery=assignee%3AYannEnzo&pane=issue&itemId=112213954&issue=PkFokam-Alumni-Network%7CCommunityBackendService%7C148
## WHAT

<!---What have you done exactly in this PR? Give the high level changes--->
Added validation to prevent users from registering for events that have already ended:

-Modified EventService.register_user_for_event to check event end_time against current time
-Added datetime validation that raises "Cannot register for past events" error
## TESTING
![image](https://github.com/user-attachments/assets/37bfb590-68a6-4c15-920c-788c323a83d3)
![Capture d'écran 2025-06-09 115313](https://github.com/user-attachments/assets/2dbdd890-b4ff-4438-b0f8-2bae7c1b9b2d)
![image](https://github.com/user-attachments/assets/70f4814d-ad2f-4836-91de-1ccf5d327feb)

